### PR TITLE
Don't auto-enable in js2-mode / javascript-mode

### DIFF
--- a/upbo.el
+++ b/upbo.el
@@ -28,6 +28,11 @@
 
 ;;  Emacs karma integration that support mode line report!
 
+;;  To enable, use:
+;;     (add-hook javascript-mode-hook 'upbo-mode)
+;;  or
+;;     (add-hook js2-mode-hook 'upbo-mode)
+
 ;;  Test Setup Usage:
 ;; (upbo-define-test
 ;;  :path "~/tui.chart/"
@@ -237,9 +242,6 @@ Key bindings:
   :group 'upbo
   :global nil
   :keymap 'upbo-mode-map)
-
-(add-hook 'js-mode-hook 'upbo-mode)
-(add-hook 'js2-mode-hook 'upbo-mode)
 
 (provide 'upbo)
 ;;; upbo.el ends here


### PR DESCRIPTION
This should be the user's choice, so instead tell them how to do it.

See https://github.com/melpa/melpa/pull/5391